### PR TITLE
pipeline: Avoid Twine

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -377,7 +377,7 @@ bool indexer_Parse(SemaManager *completion, WorkingFiles *wfiles,
     SmallString<256> msg;
     (Twine(deleted ? "delete " : "parse ") + path_to_index).toVector(msg);
     if (n_errs)
-      msg += (" error:" + Twine(n_errs) + " " + first_error).toStringRef(tmp);
+      msg += " error:" + std::to_string(n_errs) + ' ' + first_error;
     if (LOG_V_ENABLED(1)) {
       msg += "\n ";
       for (const char *arg : entry.args)


### PR DESCRIPTION
For some reason, Twine(int), when concatenated, may incorrectly become Twine(const unsigned long&) and cause a dereference crash.